### PR TITLE
Removed nuget.config with .net 6 preview packages

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,5 +1,0 @@
-<configuration>
-  <packageSources>
-    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
We get PRs from dependabot, suggesting packages from the .NET 6 preview source. We don't want that. We don't need the preview repo, now that .NET 6 is in public preview.