### PR TITLE
feat #641: Allow equal signs in user tokens

### DIFF
--- a/docs/MigratingFromRoundhousE.md
+++ b/docs/MigratingFromRoundhousE.md
@@ -21,7 +21,9 @@ grate is built using the new [`System.CommandLine`](https://github.com/dotnet/co
 - grate has a single mandatory `-cs`/`--connstring` argument for simplicity.  RH's `--database`, `--server` etc arguments are no longer allowed.
 
 - Not all previously supported tokens are available yet.  For more information see the [Token Replacement docs](TokenReplacement.md).
-- UserTokens have had two small changes.  In keeping with the `System.CommandLine` standards the `--ut` option is now passed multiple times for multiple tokens, rather than parsing a single ';' delimited string. Support for `;` delimited lists of tokens may be re-added in the future.
+- UserTokens has a change which **affects back-compatibility**   
+  - In keeping with the `System.CommandLine` standards the `--ut` option is now passed multiple times for multiple tokens, rather than parsing a single ';' delimited string as in RH.
+  - This means that you **MUST** update your scripts passing multiple tokens in a single param to use multiple `--ut` parameters instead. 
 
 - The `DropCreate` 'mode' has been merged with the `--drop` option. RH used a single-run workflow for `Normal` and `RestoreRun` modes, but needed two executions for the `DropCreate` mode.  grate uses the `--drop` option like RH but **it continues with the creation and migration afterwards**! If you have a scenario for dropping a database but _not_ then running a migration, please open an issue!
 

--- a/docs/TokenReplacement.md
+++ b/docs/TokenReplacement.md
@@ -24,8 +24,14 @@ Example:
 The tokens can then be used for token replacement in scripts:
 `ALTER TABLE {% raw %}{{MyTablePrefix}}{% endraw %}_TableName` will become `ALTER TABLE local_TableName`
 
+### ⚠️ Migration Back-Compatibility warning ⚠️
+If migrating from RoundhousE please note a change of behaviour here.  RH forced you to pass multipe user tokens as a single command line param.  Due to
+issues passing secrets etc with embedded `=` characters, grate will no longer error if passed multiple tokens in a single `--ut`!
+
+You HAVE to update your scripts to pass each user token in it's own `--ut`!
+
 ### Notes
 ⚠ If token replacement in general should be used VERY sparingly, then user tokens are an even larger foot gun.  They are built in a very simplistic manner, and are likely to fail just as simply.
 
 - If you pass clearly invalid info on the commandline (eg missing the equal sign) then grate will terminate with an error.
-- If you try and get tricksy and pass valid but broken information (eg including '{' chars, multiple '=' chars etc) then all bets are off.  Raise an issue if you have a genuine scenario you'd like help with.
+- If you try and get tricksy and pass valid but broken information (eg including '{' chars etc) then all bets are off.  Raise an issue if you have a genuine scenario you'd like help with.

--- a/src/grate.core/Infrastructure/TokenProvider.cs
+++ b/src/grate.core/Infrastructure/TokenProvider.cs
@@ -104,8 +104,9 @@ internal class TokenProvider
 
     public static (string key, string value) ParseUserToken(string userToken)
     {
-        // Splits the given "key=value" string into it's component parts.
-        var parts = userToken.Split('=', RemoveEmptyEntries | TrimEntries);
+        // Splits the given "key=value" string into it's component parts... if there's `=` signs in the value
+        // we just return it as is for #641
+        var parts = userToken.Split('=', 2, RemoveEmptyEntries | TrimEntries);
         if (parts.Length != 2)
         {
             throw new ArgumentOutOfRangeException(nameof(userToken), $"Failed to parse provided user token '{userToken}'");

--- a/unittests/Basic_tests/Infrastructure/TokenReplacerTests.cs
+++ b/unittests/Basic_tests/Infrastructure/TokenReplacerTests.cs
@@ -52,12 +52,12 @@ public class TokenReplacerTests
     [Fact]
     public void EnsureUserTokenParserWorks()
     {
-        // TestCase attribute didn't seem to like tuples...
-
         TokenProvider.ParseUserToken("token=value   ").Should().Be(("token", "value"));
         Assert.Throws<ArgumentOutOfRangeException>(() => TokenProvider.ParseUserToken("token"));
 
-        // ensure a back-compat scenario throws rather than quietly do the wrong thing.
-        Assert.Throws<ArgumentOutOfRangeException>(() => TokenProvider.ParseUserToken("token1=value1;token2=value2"));
+        // #641: While we initially wanted to protect migrating users from our change to use multiple `--ut` command line params, there's
+        // legitimate scenarios where we want an `=` in the value.  
+        TokenProvider.ParseUserToken("token1=value=with=equals").Should().Be(("token1", "value=with=equals"));
+        TokenProvider.ParseUserToken("token1=value1;token2=value2").Should().Be(("token1", "value1;token2=value2"));
     }
 }


### PR DESCRIPTION
Allow `=` chars in user tokens fixing #641, but potentially causing issues for new users migrating from Roundhouse.

