### PR TITLE
Re-add platform support for alpine/arm64

### DIFF
--- a/installers/docker/Dockerfile
+++ b/installers/docker/Dockerfile
@@ -11,7 +11,7 @@ COPY src/ ./src/
 RUN dotnet publish --framework "$TARGETFRAMEWORK" --runtime "$RUNTIME" ./src/grate/grate.csproj \
     -c release --self-contained -p:SelfContained=true /p:Version="$VERSION" -o /publish
 
-FROM alpine:3 AS installer
+FROM --platform=$BUILDPLATFORM alpine:3 AS installer
 RUN apk add icu-libs
 
 FROM installer AS runtime


### PR DESCRIPTION
Re-add the platform support for alpine/linux-arm64.
Local build:
<img width="2560" height="1216" alt="image" src="https://github.com/user-attachments/assets/0912e4fb-f69b-4288-8fe2-668083c7b439" />
