### PR TITLE
Build: Update build to use trusted publish for library nugets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,10 +62,18 @@ jobs:
       with:
         name: grate-dotnet-tool-${{ needs.set-version-number.outputs.nuGetVersion }}
         path: /tmp/grate/nupkg/*   
-
+    
+      # Get a short-lived NuGet API key (Trusted Publishing https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
+      id: login
+      with:
+        user: wokket # ${{ secrets.NUGET_USER }}
+        
     - name: Push to Nuget.org
       if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
-      run: dotnet nuget push /tmp/grate/nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{secrets.NUGET_ORG_KEY}} --skip-duplicate
+      run: dotnet nuget push /tmp/grate/nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{steps.login.outputs.NUGET_API_KEY}} --skip-duplicate
   
   build-nuget-package:
     needs: set-version-number


### PR DESCRIPTION
Already used for the global tool.