### PR TITLE
fix: set the RuntimeIdentifiers to empty when building the docker image.

### DIFF
--- a/installers/docker/Dockerfile
+++ b/installers/docker/Dockerfile
@@ -9,7 +9,8 @@ COPY *.props ./
 COPY *.ruleset ./
 COPY src/ ./src/
 RUN dotnet publish --framework "$TARGETFRAMEWORK" --runtime "$RUNTIME" ./src/grate/grate.csproj \
-    -c release --self-contained -p:SelfContained=true /p:Version="$VERSION" -o /publish
+    -c release --self-contained -p:SelfContained=true /p:Version="$VERSION" /p:RuntimeIdentifiers="" \
+    -o /publish
 
 FROM --platform=$BUILDPLATFORM alpine:3 AS installer
 RUN apk add icu-libs


### PR DESCRIPTION
This PR fixes the disk space issue in Docker when building multiple platforms.
When restoring the NuGet packages, if we define the `RuntimeIdentifiers` like below, it will download all the binaries of all platforms, which causes a lot slower and disk space.
```xml
  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
    <DebugType>None</DebugType>
    <RuntimeIdentifiers>win-x64;win-x86;win-arm64;linux-musl-x64;linux-musl-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
    <ToolCommandName>grate</ToolCommandName>
  </PropertyGroup>
```

Build Output:
<img width="668" height="1117" alt="image" src="https://github.com/user-attachments/assets/f90f56b9-8642-4e09-b3d5-cf5041a2ca7b" />

DockerHub.
<img width="1755" height="1239" alt="image" src="https://github.com/user-attachments/assets/86214310-e44c-485a-8c82-e0fc53a9e0c0" />


#695