### PR TITLE
Changing the NuGet Trusted Publishing to use the username in secret.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,17 +67,16 @@ jobs:
         path: /tmp/grate/nupkg/*   
     
       # Get a short-lived NuGet API key (Trusted Publishing https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
-      # TODO: Replace hard coded username with ${{ secrets.NUGET_USER }} or similar
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1
       if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
       id: login
       with:
-        user: wokket 
+        user: ${{ secrets.NUGET_USER }} 
         
     - name: Push to Nuget.org
       if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
-      run: dotnet nuget push /tmp/grate/nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key "${{steps.login.outputs.NUGET_API_KEY}}" --skip-duplicate
+      run: dotnet nuget push /tmp/grate/nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --skip-duplicate
   
   build-nuget-package:
     needs: set-version-number


### PR DESCRIPTION
After checking the document and config (from the image above), I think the issue can be username (to login) is mismatched with Nuget.
This PR changes to use the repo secret, so that another contributor can push into their repo, respectively.

Setup I think it should work:
Go to repo -> Settings -> Secrets and variables -> Actions -> New repository secret

Name: NUGET_USER
Secret: grate-devs

<img width="627" height="597" alt="image" src="https://github.com/user-attachments/assets/53a5c427-4ed9-49fd-a4d1-aa2a38223f5d" />

My result:
<img width="1957" height="195" alt="image" src="https://github.com/user-attachments/assets/8e3e2b50-055a-4160-9f31-9095914ad3df" />

#704 

