### PR TITLE
Trying to get multi-arch docker build to work again (still doesn't work yet, disabled arm64 build in GitHub Actions for now)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,13 +178,13 @@ jobs:
     name: Build cli
     needs: set-version-number
 
-    # Use macos-14 to build osx-arm64, it runs on M1, see 
+    # Use macos-15 to build osx-arm64, it runs on M1, see 
     # https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
     #
     # I've earlier had problems with that the trimmed, self-contained binary for osx-arm64 that was built on Linux
     # did not work when opened on an actual mac with arm64.
 
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         arch: [ "osx-arm64" ]
@@ -269,7 +269,22 @@ jobs:
     needs: 
      - set-version-number
      #- build-standalone ## no need, we build directly from source
-    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration:
+          - name: "amd64"
+            arch: "linux/amd64"
+            runs-on: ubuntu-latest
+          # Doesn't work well with docker-in-docker on amd64 runners, so we skip it for now
+          # - name: "arm64" 
+          #   arch: "linux/arm64"
+          #   runs-on: macos-15
+     
+    runs-on: ${{ matrix.configuration.runs-on }}
+
+    
     #if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
     env:
       #REGISTRY: ghcr.io
@@ -278,10 +293,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    # - uses: actions/download-artifact@v6 # download from another artifact is not a good idea, we need to build directly from source
-    #   with:
-    #     name: grate-linux-musl-x64-self-contained-${{ needs.set-version-number.outputs.nuGetVersion }}
-    #     path: installers/docker/
     
     - name: Set up Docker
       uses: docker/setup-docker-action@v4
@@ -321,7 +332,8 @@ jobs:
       with:
         file: ./installers/docker/Dockerfile
         context: .
-        platforms: linux/amd64,linux/arm64
+        #platforms: linux/amd64,linux/arm64
+        platforms: ${{ matrix.configuration.arch }}
         push: ${{ needs.set-version-number.outputs.is-release == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,13 +85,13 @@ jobs:
     name: Build cli
     needs: set-version-number
 
-    # Use macos-14 to build osx-arm64, it runs on M1, see 
+    # Use macos-15 to build osx-arm64, it runs on M1, see 
     # https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
     #
     # I've earlier had problems with that the trimmed, self-contained binary for osx-arm64 that was built on Linux
     # did not work when opened on an actual mac with arm64.
 
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         arch: [ "osx-arm64" ]
@@ -154,7 +154,7 @@ jobs:
     name: Build tests
     needs: set-version-number
 
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         arch: [ "osx-arm64" ]
@@ -416,8 +416,8 @@ jobs:
           - name: macos-latest
             arch: osx-x64
             executable: grate
-          # macos-14 is M1 (arm64)
-          - name: macos-14
+          # macos-15 is M1 (arm64)
+          - name: macos-15
             arch: osx-arm64
             executable: grate
         database: ${{ fromJson(needs.setup-test-environment.outputs.dbs) }}

--- a/build-docker-local.sh
+++ b/build-docker-local.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Build Docker image locally the same way as GitHub Actions does
+# This script mimics the build-docker-image job in .github/workflows/build.yml
+
+set -e
+
+# Parse command line arguments
+PLATFORM="linux/amd64,linux/arm64"
+LOAD_IMAGE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --platform)
+            PLATFORM="$2"
+            LOAD_IMAGE=true
+            shift 2
+            ;;
+        --amd64)
+            PLATFORM="linux/amd64"
+            LOAD_IMAGE=true
+            shift
+            ;;
+        --arm64)
+            PLATFORM="linux/arm64"
+            LOAD_IMAGE=true
+            shift
+            ;;
+        --load)
+            LOAD_IMAGE=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--platform linux/amd64|linux/arm64] [--amd64] [--arm64] [--load]"
+            exit 1
+            ;;
+    esac
+done
+
+# Get version from GitVersion if available, otherwise use a default
+if command -v dotnet &> /dev/null; then
+    echo "Attempting to get version using GitVersion..."
+    if dotnet tool list -g | grep -q gitversion.tool; then
+        VERSION=$(dotnet gitversion /showvariable NuGetVersionV2 2>/dev/null || echo "1.0.0-local")
+    else
+        echo "GitVersion not installed globally. Using default version."
+        VERSION="1.0.0-local"
+    fi
+else
+    VERSION="1.0.0-local"
+fi
+
+echo "Building Docker image with version: $VERSION"
+echo "Image name: grate-devs/grate"
+echo "Platform(s): $PLATFORM"
+echo ""
+
+# Create a builder instance if it doesn't exist
+if ! docker buildx ls | grep -q "multiarch-builder"; then
+    echo "Creating multiarch-builder..."
+    docker buildx create --name multiarch-builder --use
+else
+    echo "Using existing multiarch-builder..."
+    docker buildx use multiarch-builder
+fi
+
+# Build arguments
+BUILD_ARGS=(
+    --file ./installers/docker/Dockerfile
+    --platform "$PLATFORM"
+    --build-arg VERSION="$VERSION"
+    --tag grate-devs/grate:$VERSION
+    --tag grate-devs/grate:latest
+)
+
+# Add --load if single platform or explicitly requested
+if [ "$LOAD_IMAGE" = true ]; then
+    BUILD_ARGS+=(--load)
+    echo "Loading image into Docker (single platform only)"
+else
+    echo "Building multi-platform (not loading into Docker)"
+fi
+
+# Build for specified platform(s)
+docker buildx build "${BUILD_ARGS[@]}" .
+
+echo ""
+echo "Build completed successfully!"
+echo "Image tags:"
+echo "  - grate-devs/grate:$VERSION"
+echo "  - grate-devs/grate:latest"
+echo ""
+echo "To test the image:"
+echo "  docker run --rm --platform $PLATFORM grate-devs/grate:latest --help"

--- a/installers/docker/Dockerfile
+++ b/installers/docker/Dockerfile
@@ -12,10 +12,8 @@ RUN dotnet publish --framework "$TARGETFRAMEWORK" --runtime "$RUNTIME" ./src/gra
     -c release --self-contained -p:SelfContained=true /p:Version="$VERSION" /p:RuntimeIdentifiers="" \
     -o /publish
 
-FROM --platform=$TARGETPLATFORM alpine:3 AS installer
-RUN apk add icu-libs
-
-FROM installer AS runtime
+FROM alpine:3 AS runtime
+RUN apk add --no-cache icu-libs
 WORKDIR /app
 
 COPY --chmod=0755 --from=build /publish .


### PR DESCRIPTION
Trying to get multi-arch docker build to work again (still doesn't work yet, disabled arm64 build in GitHub Actions for now)

* Run "build docker image" step on arm64 build agent
* Changed github agents macos-14 to macos-15
* Try matrix docker publish
* Skip arm64 build on github actions for now, doesn't work well yet
