### PR TITLE
Flatten folder when introduce the zip file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
       if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
       run: |
         name=grate-${{ matrix.arch }}-self-contained-${{ needs.set-version-number.outputs.nuGetVersion }}.zip
-        zip -r $name ./publish/${{ matrix.arch }}/self-contained
+        zip -j $name ./publish/${{ matrix.arch }}/self-contained/*
         gh release upload ${{ needs.set-version-number.outputs.semVer }} $name --clobber
       env:
         GH_TOKEN: ${{ github.token }}
@@ -215,7 +215,7 @@ jobs:
       if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
       run: |
         name=grate-${{ matrix.arch }}-self-contained-${{ needs.set-version-number.outputs.nuGetVersion }}.zip
-        zip -r $name ./publish/${{ matrix.arch }}/self-contained
+        zip -j $name ./publish/${{ matrix.arch }}/self-contained/*
         gh release upload ${{ needs.set-version-number.outputs.semVer }} $name --clobber
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR to fix the issue https://github.com/grate-devs/grate/issues/689 when pushing the zip package. We need to flatten folder instead of including the path. See latest result below.

<img width="1211" height="336" alt="image" src="https://github.com/user-attachments/assets/ebfdc7a8-7422-4e7d-b0b7-4d4e171e937f" />