### PR TITLE
Configure kramdown typographic ndash sequence

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,9 @@
 remote_theme: pmarsceill/just-the-docs
 
+kramdown:
+  typographic_symbols:
+    ndash: __
+
 # Aux links for the upper right navigation
 aux_links:
   "grate on GitHub":


### PR DESCRIPTION
The default "--" is converted to ndash which produces an incorrect view of the docs at https://grate-devs.github.io/grate/configuration-options

Currently double hyphens are displayed as an ndash:
<img width="741" height="196" alt="image" src="https://github.com/user-attachments/assets/b8e6b9cb-dd99-41ea-b8ec-b98edca58500" />
