### PR TITLE
Clarify command timeout descriptions in documentation

### DIFF
--- a/docs/ConfigurationOptions/index.md
+++ b/docs/ConfigurationOptions/index.md
@@ -26,8 +26,8 @@ grate --connectionstring="Server=(localdb)\MSSQLLocalDB;Integrated Security=true
 | --folders | Default folders as described in [Getting started](../GettingStarted.md) | Folder configuration, see [Folder configuration](FolderConfiguration.md) for details. | 
 | -o<br>--output<br>--outputPath &lt;outputPath&gt; | %LOCALAPPDATA%/grate | This is where everything related to the migration is stored. This includes any backups, all items that ran, permission dumps, logs, etc. |
 | --accesstoken &lt;token&gt; | - | Specify an access token to use when connecting to SQL Server. |
-| -ct<br>--commandtimeout &lt;commandtimeout&gt; | 60s | This is the timeout when commands are run. This is not for admin commands or restore. |
-| -cta<br>--admincommandtimeout &lt;admincommandtimeout&gt; | 300 | This is the timeout when administration commands are run (except for restore, which has its own) |
+| -ct<br>--commandtimeout &lt;commandtimeout&gt; | 60 | This is the timeout in seconds when commands are run. This is not for admin commands or restore. |
+| -cta<br>--admincommandtimeout &lt;admincommandtimeout&gt; | 300 | This is the timeout in seconds when administration commands are run (except for restore, which has its own) |
 | --databasetype<br>--dbt<br>--dt <mariadb \| oracle \| postgresql \| sqlite \| sqlserver> | sqlserver | Tells grate what type of database it is running on. |
 | -t<br>--transaction<br>--trx <transaction> | false | Run the migration in a transaction |
 | --sc<br>--schema<br>--schemaname &lt;schemaname&gt; | grate | The schema to use for the migration tables.  If you're upgrading from RoundhousE you'll probably want this! |


### PR DESCRIPTION
Updated command timeout descriptions to specify units in seconds. CommandTimeout setting is an int, so without the "s" that was wrongly present in the docs