### PR TITLE
build: Fix broken GitVersion outputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
     name: Set version number
     runs-on: ubuntu-latest
     outputs:
-      nuGetVersion: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
+      nuGetVersion: ${{ steps.gitversion.outputs.MajorMinorPatch }}
       semVer: ${{ steps.gitversion.outputs.fullSemVer }}
-      is-release: ${{ steps.gitversion.outputs.CommitsSinceVersionSource == 0 }}
+      is-release: ${{ steps.gitversion.outputs.versionSourceDistance == 0 }}
       #is-release: 'true'
     
     steps:
@@ -24,17 +24,28 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
+        
     - name: Checkout
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+        
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v4.6.0
+      uses: gittools/actions/gitversion/setup@v4.7.0
       with:
         versionSpec: '6.x'
+        
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v4.6.0
+      uses: gittools/actions/gitversion/execute@v4.7.0
+    
+    
+    - name: Display Version Information
+      run: |
+        echo "MajorMinorPatch: ${{ steps.gitversion.outputs.MajorMinorPatch }}"
+        echo "versionSourceDistance: ${{ steps.gitversion.outputs.versionSourceDistance }}"
+        echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
+        echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
 
   build-netcore-tool:
     needs: set-version-number

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     name: Set version number
     runs-on: ubuntu-latest
     outputs:
-      nuGetVersion: ${{ steps.gitversion.outputs.MajorMinorPatch }}
+      nuGetVersion: ${{ steps.gitversion.outputs.majorMinorPatch }}
       semVer: ${{ steps.gitversion.outputs.fullSemVer }}
       is-release: ${{ steps.gitversion.outputs.versionSourceDistance == 0 }}
       #is-release: 'true'
@@ -66,7 +66,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet pack ./src/grate/grate.csproj -p:SelfContained=true -p:PackAsTool=true -p:PackageOutputPath=/tmp/grate/nupkg #SelfContained for #714
+      run: dotnet pack ./src/grate/grate.csproj -p:SelfContained=true -p:PackAsTool=true -p:PackageOutputPath=/tmp/grate/nupkg -p:PackageVersion=${{ needs.set-version-number.outputs.semVer }} #SelfContained for #714
       env:
         VERSION: ${{ needs.set-version-number.outputs.nuGetVersion }}
       
@@ -122,7 +122,7 @@ jobs:
       run: dotnet restore
 
     - name: Pack Nuget package ${{ matrix.package }}
-      run: dotnet pack ./src/${{ matrix.package }} -c Release --include-symbols -o /tmp/grate/nupkg /p:Version=${{ env.VERSION }}
+      run: dotnet pack ./src/${{ matrix.package }} -c Release --include-symbols -o /tmp/grate/nupkg /p:Version=${{ env.VERSION }} -p:PackageVersion=${{ needs.set-version-number.outputs.semVer }}
       env:
         VERSION: ${{ needs.set-version-number.outputs.nuGetVersion }}
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,9 +66,7 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet pack ./src/grate/grate.csproj -p:SelfContained=true -p:PackAsTool=true -p:PackageOutputPath=/tmp/grate/nupkg -p:PackageVersion=${{ needs.set-version-number.outputs.semVer }} #SelfContained for #714
-      env:
-        VERSION: ${{ needs.set-version-number.outputs.nuGetVersion }}
+      run: dotnet pack ./src/grate/grate.csproj -p:SelfContained=true -p:PackAsTool=true -p:PackageOutputPath=/tmp/grate/nupkg -p:version=${{ needs.set-version-number.outputs.nuGetVersion }} -p:PackageVersion=${{ needs.set-version-number.outputs.semVer }} #SelfContained for #714
       
     - name: Upload published tool artifact
       uses: actions/upload-artifact@v7

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
     name: Set version number
     runs-on: ubuntu-latest
     outputs:
-      nuGetVersion: ${{ steps.gitversion.outputs.SemVer }}
+      nuGetVersion: ${{ steps.gitversion.outputs.majorMinorPatch }}
       semVer: ${{ steps.gitversion.outputs.fullSemVer }}
       is-release: ${{ steps.gitversion.outputs.versionSourceDistance == 0 }}
       #is-release: 'true'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,9 +24,9 @@ jobs:
     name: Set version number
     runs-on: ubuntu-latest
     outputs:
-      nuGetVersion: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
+      nuGetVersion: ${{ steps.gitversion.outputs.SemVer }}
       semVer: ${{ steps.gitversion.outputs.fullSemVer }}
-      is-release: ${{ steps.gitversion.outputs.CommitsSinceVersionSource == 0 }}
+      is-release: ${{ steps.gitversion.outputs.versionSourceDistance == 0 }}
       #is-release: 'true'
     
     steps:
@@ -45,7 +45,7 @@ jobs:
     - name: Determine Version
       id: gitversion
       uses: gittools/actions/gitversion/execute@v4.6.0
-
+      
   build-standalone:
     name: Build cli
     needs: set-version-number


### PR DESCRIPTION
GitVersion V4 has removed the old output variables we used to use, and also stopped outputting the variables so it's harder to work out which values to use.

This also (hopefully) allows us to publish pre-release nugets for testing without alerting the entire world to a new (broken) version.