### PR TITLE
feat(docker): Update docker build to use buildx for QEMU emulation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,21 +275,8 @@ jobs:
      - set-version-number
      #- build-standalone ## no need, we build directly from source
 
-    strategy:
-      fail-fast: false
-      matrix:
-        configuration:
-          - name: "amd64"
-            arch: "linux/amd64"
-            runs-on: ubuntu-latest
-          # Doesn't work well with docker-in-docker on amd64 runners, so we skip it for now
-          # - name: "arm64" 
-          #   arch: "linux/arm64"
-          #   runs-on: macos-15
-     
-    runs-on: ${{ matrix.configuration.runs-on }}
+    runs-on: ubuntu-latest
 
-    
     #if: ${{ needs.set-version-number.outputs.is-release == 'true' }}
     env:
       #REGISTRY: ghcr.io
@@ -297,17 +284,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    
-    - name: Set up Docker
-      uses: docker/setup-docker-action@v5
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
       with:
-        daemon-config: |
-          {
-            "debug": true,
-            "features": {
-              "containerd-snapshotter": true
-            }
-          }
+        driver: docker-container
 
     - name: Log in to the Container registry
       uses: docker/login-action@v4
@@ -336,8 +317,7 @@ jobs:
       with:
         file: ./installers/docker/Dockerfile
         context: .
-        #platforms: linux/amd64,linux/arm64
-        platforms: ${{ matrix.configuration.arch }}
+        platforms: linux/amd64,linux/arm64
         push: ${{ needs.set-version-number.outputs.is-release == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This will build arm64 containers successfully on github runners by emulation ARM64. The dockefile is correctly configured to target arm64 and create a correct build.

I remove the strategy as it's done in a single combined platform build for both. Similar to how the `build.docker.local.sh` file works. The change removes the `containerd` snapshotter and debug flag, it can be returned but we have to use buildkit flags