### PR TITLE
Fix the SSH.NET dependency issue (security)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,11 +32,11 @@
      Bundle 3.x pulls the patched branch (lib.e_sqlite3 3.50.x, SQLite 3.50.x); 2.1.11 is the last vulnerable 2.1.x.
     -->
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageVersion Include="Testcontainers" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.MariaDb" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.Oracle" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.MariaDb" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.Oracle" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.14.0" />
     <PackageVersion Include="Xunit.DependencyInjection.Logging" Version="11.0.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
   </ItemGroup>


### PR DESCRIPTION
When restoring packages you get an error about the ssh.net dependency and an open security vunerability, this is pulled in by the testcontainers dependency, so resolve it by updating it.