### PR TITLE
Run Unit Tests on Windows as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,46 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "windows-latest" ]
-        category: [ "Basic_tests", "SqlServer", "SqlServerCaseSensitive", "PostgreSQL", "MariaDB", "Sqlite", "Oracle"  ]
+        include:
+          - os: ubuntu-latest
+            category: Basic_tests
+            test_filter: ''
+          - os: ubuntu-latest
+            category: SqlServer
+            test_filter: ''
+          - os: ubuntu-latest
+            category: SqlServerCaseSensitive
+            test_filter: ''
+          - os: ubuntu-latest
+            category: PostgreSQL
+            test_filter: ''
+          - os: ubuntu-latest
+            category: MariaDB
+            test_filter: ''
+          - os: ubuntu-latest
+            category: Sqlite
+            test_filter: ''
+          - os: ubuntu-latest
+            category: Oracle
+            test_filter: ''
+          - os: windows-latest
+            category: Basic_tests
+            test_filter: ''
+          - os: windows-latest
+            category: Sqlite
+            test_filter: ''
+          - os: windows-latest
+            category: SqlServer
+            test_filter: FullyQualifiedName~SqlServer.Basic_tests
+          - os: windows-latest
+            category: SqlServerCaseSensitive
+            test_filter: FullyQualifiedName~SqlServerCaseSensitive.Basic_tests
+          - os: windows-latest
+            category: MariaDB
+            test_filter: FullyQualifiedName~MariaDB.Basic_tests
+          - os: windows-latest
+            category: Oracle
+            test_filter: FullyQualifiedName~Oracle.Basic_tests
         #category: [ "Basic_tests", "Sqlite"  ]
 
     steps:
@@ -92,7 +130,18 @@ jobs:
         $outDir = Join-Path "${{ runner.temp }}" "test-results"
         New-Item -ItemType Directory -Path $outDir -Force | Out-Null
 
-        dotnet test --project unittests/${{ matrix.category }} --coverage --coverage-output-format xml --coverage-output "$outDir/${{ matrix.category }}.xml"
+        $args = @(
+          "--project", "unittests/${{ matrix.category }}",
+          "--coverage",
+          "--coverage-output-format", "xml",
+          "--coverage-output", "$outDir/${{ matrix.category }}.xml"
+        )
+
+        if ("${{ matrix.test_filter }}") {
+          $args += @("--filter", "${{ matrix.test_filter }}")
+        }
+
+        dotnet test @args
       env:
         LogLevel: Warning
         TZ: UTC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,13 @@ jobs:
   test:
     name: Run tests
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     #needs: build-code
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ "ubuntu-latest", "windows-latest" ]
         category: [ "Basic_tests", "SqlServer", "SqlServerCaseSensitive", "PostgreSQL", "MariaDB", "Sqlite", "Oracle"  ]
         #category: [ "Basic_tests", "Sqlite"  ]
 
@@ -86,12 +87,12 @@ jobs:
           9.0.x
           10.0.x
     - name: Test
+      shell: pwsh
       run: |
-        dotnet test \
-        --project unittests/${{ matrix.category }} \
-        --coverage \
-        --coverage-output-format xml \
-        --coverage-output /tmp/test-results/${{ matrix.category }}.xml
+        $outDir = Join-Path "${{ runner.temp }}" "test-results"
+        New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+        dotnet test --project unittests/${{ matrix.category }} --coverage --coverage-output-format xml --coverage-output "$outDir/${{ matrix.category }}.xml"
       env:
         LogLevel: Warning
         TZ: UTC
@@ -100,9 +101,9 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: "${{ matrix.category }} XML test results"
+        name: "${{ matrix.os }} ${{ matrix.category }} XML test results"
         path: |
-          /tmp/test-results/${{ matrix.category }}.xml
+          ${{ runner.temp }}/test-results/${{ matrix.category }}.xml
         retention-days: 1
 
 


### PR DESCRIPTION
Adds Windows as a target for running the non-docker unit tests. This is so errors that only appear on Windows are more easily caught.